### PR TITLE
ToString for CSV Parser results

### DIFF
--- a/csvparser.go
+++ b/csvparser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 )
 
@@ -270,4 +271,57 @@ func (c *CsvParser[ReadTo]) runOnFinish() {
 	if c.onFinish != nil {
 		c.onFinish()
 	}
+}
+
+/*
+Given array of structs from the parsed csv, prints out the contents of the file parsing in a nice string format.
+The input of the function can take in any type of structs with any number of fields within the struct.
+*/
+func parseToString(arr []interface{}) string {
+	result := ""
+
+	// For each struct in the given array
+	for j, val := range arr {
+		line := "|-> ("
+
+		// Use reflect package to obtain number of fields in struct
+		v := reflect.ValueOf(val)
+		values := make([]interface{}, v.NumField())
+
+		// Store array of each field in the struct
+		for i := 0; i < v.NumField(); i++ {
+			values[i] = v.Field(i).Interface()
+		}
+
+		if j == 0 {
+			// Add top outline of the printed result
+			for k := 0; k < 20*(v.NumField())+10; k++ {
+				result += "_"
+			}
+			result += "\n"
+		}
+
+		for i, printVal := range values {
+			// Translate each field to a string. Each field started as an interface.
+			str := fmt.Sprintf("%v", printVal)
+			line += str
+
+			if i < len(values)-1 {
+				// Add buffer of spaces between each field on every row. The buffer size is set to 25 chars.
+				for i := 0; i < 25-len(str); i++ {
+					line += " "
+				}
+			} else {
+				line += ")"
+			}
+
+		}
+		if j != 0 {
+			result += "\n"
+		}
+		result += line
+	}
+
+	// Return string of the struct contents in a more readable format
+	return result
 }

--- a/csvparser.go
+++ b/csvparser.go
@@ -277,7 +277,7 @@ func (c *CsvParser[ReadTo]) runOnFinish() {
 Given array of structs from the parsed csv, prints out the contents of the file parsing in a nice string format.
 The input of the function can take in any type of structs with any number of fields within the struct.
 */
-func parseToString(arr []interface{}) string {
+func ParseToString(arr []interface{}) string {
 	result := ""
 
 	// For each struct in the given array

--- a/readme.MD
+++ b/readme.MD
@@ -60,6 +60,12 @@ parser.AddColumnParser("age", func (value string, into *Person) error {
 
 // res is []Person type
 res, err := parser.Parse()
+translate := make([]interface{}, len(res))
+	for i, s := range res {
+		translate[i] = s
+	}
+	resultString := parseToString(translate)
+	fmt.Println(resultString)
 ```
 
 Note: as long as there is a parser for the header that you want, the order of the .csv columns will not matter


### PR DESCRIPTION
The ParseToString() function added to the parser file allows a user to input their parsed structs and get back a string version of its contents. The function prints the values of the structs regardless of the var types for the fields within each struct.